### PR TITLE
feat: add dependency to caddy and dnsmasq

### DIFF
--- a/linkup.rb
+++ b/linkup.rb
@@ -12,6 +12,8 @@ class Linkup < Formula
   end
 
   depends_on "cloudflared"
+  depends_on "dnsmasq"
+  depends_on "caddy"
 
   def install
     bin.install 'linkup'


### PR DESCRIPTION
### Description
These two dependencies are required for the new Linkup [localdns subcommand.](https://github.com/mentimeter/linkup/pull/28)

### Added dependencies
- [Caddy](https://caddyserver.com/)
- [dnsmasq](https://thekelleys.org.uk/dnsmasq/doc.html)