### PR TITLE
chore: remove dependency to Caddy

### DIFF
--- a/linkup.rb
+++ b/linkup.rb
@@ -33,7 +33,6 @@ class Linkup < Formula
 
   depends_on "cloudflared"
   depends_on "dnsmasq"
-  depends_on "caddy"
 
   def install
     bin.install 'linkup'


### PR DESCRIPTION
Caddy now is managed by the CLI itself since we need to download our custom built one from the Linkup release.