### PR TITLE
feat!: remove dependency on dnsmasq

### DIFF
--- a/linkup.rb
+++ b/linkup.rb
@@ -32,7 +32,6 @@ class Linkup < Formula
   end
 
   depends_on "cloudflared"
-  depends_on "dnsmasq"
 
   def install
     bin.install 'linkup'


### PR DESCRIPTION
⚠️ To be merged after https://github.com/mentimeter/linkup/pull/209 is released

As of Linkup 3.0.0, dnsmasq is not necessary anymore.

Related to SHIP-2057

